### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,36 +1,36 @@
 {
-    "name": "twitter-stream-api",
-    "version": "0.3.0",
-    "description": "A streaming Twitter Stream API client with extended exposure of the underlaying protocol events",
-    "main": "lib/main.js",
-    "repository": {
-        "type": "git",
-        "url": "git@github.com:trygve-lie/twitter-stream-api.git"
-    },
-    "bugs": {
+  "name": "twitter-stream-api",
+  "version": "0.3.0",
+  "description": "A streaming Twitter Stream API client with extended exposure of the underlaying protocol events",
+  "main": "lib/main.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:trygve-lie/twitter-stream-api.git"
+  },
+  "bugs": {
     "url": "https://github.com/trygve-lie/twitter-stream-api/issues"
-    },
-    "scripts": {
-        "pretest": "jshint ./lib/*.js ./test/*.js",
-        "test": "tap test/*.js"
-    },
-    "keywords": [
-        "twitter",
-        "stream"
-    ],
-    "author": "Trygve Lie <github@trygve-lie.com>",
-    "license": "MIT",
-    "dependencies": {
-        "readable-stream": "2.x",
-        "core-util-is": "1.x",
-        "request": "2.x",
-        "backoff-linear-strategy": "1.x",
-        "backoff": "2.4.x",
-        "emits": "3.x"
-    },
-    "devDependencies": {
-        "request-debug": "0.2.x",
-        "jshint": "latest",
-        "tap": "latest"
-    }
+  },
+  "scripts": {
+    "pretest": "jshint ./lib/*.js ./test/*.js",
+    "test": "tap test/*.js"
+  },
+  "keywords": [
+    "twitter",
+    "stream"
+  ],
+  "author": "Trygve Lie <github@trygve-lie.com>",
+  "license": "MIT",
+  "dependencies": {
+    "readable-stream": "2.0.2",
+    "core-util-is": "1.0.1",
+    "request": "2.64.0",
+    "backoff-linear-strategy": "1.0.0",
+    "backoff": "2.4.1",
+    "emits": "3.0.0"
+  },
+  "devDependencies": {
+    "request-debug": "0.2.0",
+    "jshint": "2.8.0",
+    "tap": "2.0.0"
+  }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
