### PR TITLE
Update request dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "readable-stream": "2.2.9",
     "core-util-is": "1.0.2",
-    "request": "2.81.0",
+    "request": "^2.81.0",
     "backoff-linear-strategy": "1.0.0",
     "backoff": "2.5.0",
     "emits": "3.0.0"


### PR DESCRIPTION
this older request dep, depends on an old version of ajv that requests deps with expressions, which throws a Critical dependency warning in webpack

https://github.com/request/request/commit/51806f8ad32ec8fc3050a58467d5c2ac8742468b#diff-b9cfc7f2cdf78a7f4b91a753d10865a2